### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ovos-plugin-manager>=0.0.5
-requests ~= 2.31.0
+requests


### PR DESCRIPTION
dont pin requests version, let a major OVOS component do that instead

avoid errors like 
```
jul 10 18:33:14 LenovoSatellite hivemind-voice-sat[21219]: pkg_resources.DistributionNotFound: The 'requests~=2.31.0' distribution was not found and is required by ovos-tts-plugin-server

```